### PR TITLE
Make tests throwing exceptions follow the Given-When-Then format

### DIFF
--- a/src/test/java/org/paumard/spliterators/AccumulatingEntriesSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/AccumulatingEntriesSpliteratorTest.java
@@ -22,11 +22,13 @@ import org.testng.annotations.Test;
 
 import java.util.AbstractMap;
 import java.util.Map;
+import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -108,20 +110,32 @@ public class AccumulatingEntriesSpliteratorTest {
         assertThat(count).isEqualTo(3L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_an_accumulate_stream_on_a_null_stream() {
+        // Given
+        Stream<Map.Entry<Object, Integer>> stream = null;
+        BinaryOperator<Integer> operator = Integer::sum;
 
-        StreamsUtils.accumulateEntries(null, Integer::sum);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.accumulateEntries(stream, operator));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_an_accumulate_stream_on_a_null_operator() {
+        // Given
+        Stream<Map.Entry<Integer, String>> stream = Stream.of(
+                new AbstractMap.SimpleEntry<>(1, "1"),
+                new AbstractMap.SimpleEntry<>(2, "2")
+        );
+        BinaryOperator<String> operator = null;
 
-        StreamsUtils.accumulateEntries(
-                Stream.of(
-                        new AbstractMap.SimpleEntry<>(1, "1"),
-                        new AbstractMap.SimpleEntry<>(2, "2")
-                ),
-                null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.accumulateEntries(stream, operator));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/AccumulatingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/AccumulatingSpliteratorTest.java
@@ -20,11 +20,13 @@ import org.paumard.spliterators.util.TryAdvanceCheckingSpliterator;
 import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
+import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -83,15 +85,29 @@ public class AccumulatingSpliteratorTest {
         assertThat(count).isEqualTo(3L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_an_accumulate_stream_on_a_null_stream() {
+        // Given
+        BinaryOperator<Integer> operator = Integer::sum;
+        Stream<Integer> stream = null;
 
-        StreamsUtils.accumulate(null, Integer::sum);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.accumulate(stream, operator));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_an_accumulate_stream_on_a_null_operator() {
+        // Given
+        Stream<Integer> stream = Stream.of(1, 1, 1, 1, 1);
+        BinaryOperator<Integer> operator = null;
 
-        StreamsUtils.accumulate(Stream.of(1, 1, 1, 1, 1), null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.accumulate(stream, operator));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/CrossProductNaturalyOrderedSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/CrossProductNaturalyOrderedSpliteratorTest.java
@@ -27,6 +27,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 
 /**
@@ -164,9 +165,16 @@ public class CrossProductNaturalyOrderedSpliteratorTest {
         assertThat(count).isEqualTo(6L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_crossing_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<Object> stream = null;
+        Comparator<Object> comparator = null;
 
-        Stream<Map.Entry<String, String>> stream = StreamsUtils.crossProductOrdered(null, null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.crossProductOrdered(stream, comparator));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/CrossProductNoDoublesSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/CrossProductNoDoublesSpliteratorTest.java
@@ -27,6 +27,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -143,9 +144,15 @@ public class CrossProductNoDoublesSpliteratorTest {
         assertThat(count).isEqualTo(12L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_crossing_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<Object> stream = null;
 
-        Stream<Map.Entry<String, String>> stream = StreamsUtils.crossProductNoDoubles(null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.crossProductNoDoubles(stream));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/CrossProductSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/CrossProductSpliteratorTest.java
@@ -27,6 +27,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -158,9 +159,15 @@ public class CrossProductSpliteratorTest {
         assertThat(count).isEqualTo(16L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_crossing_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<Object> stream = null;
 
-        Stream<Map.Entry<String, String>> stream = StreamsUtils.crossProduct(null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.crossProduct(stream));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/FilteringAllMaxSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/FilteringAllMaxSpliteratorTest.java
@@ -27,6 +27,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -98,23 +99,35 @@ public class FilteringAllMaxSpliteratorTest {
         assertThat(count).isEqualTo(1L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_stream() {
-
         // Given
+        Stream<String> stream = null;
         Comparator<String> comparator = Comparator.naturalOrder();
 
         // When
-        List<String> list = StreamsUtils.filteringAllMax(null, comparator).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+                    StreamsUtils.filteringAllMax(stream, comparator)
+                            .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_comparator() {
-
         // Given
         Stream<String> strings = Stream.of("1", "1", "2", "2", "3", "3");
+        Comparator<String> comparator = null;
 
         // When
-        List<String> list = StreamsUtils.filteringAllMax(strings, null).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+                StreamsUtils.filteringAllMax(strings, comparator)
+                        .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/FilteringMaxKeysSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/FilteringMaxKeysSpliteratorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -40,6 +41,7 @@ public class FilteringMaxKeysSpliteratorTest {
 
         // When
         long n = StreamsUtils.filteringMaxKeys(strings, 2, comparator).count();
+
         // Then
         assertThat(n).isEqualTo(0L);
     }
@@ -176,23 +178,37 @@ public class FilteringMaxKeysSpliteratorTest {
         assertThat(count).isEqualTo(2L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_stream() {
-
         // Given
+        Stream<String> strings = null;
+        int numberOfMaxes = 10;
         Comparator<String> comparator = Comparator.naturalOrder();
 
         // When
-        List<String> list = StreamsUtils.filteringMaxKeys(null, 10, comparator).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+                StreamsUtils.filteringMaxKeys(strings, numberOfMaxes, comparator)
+                        .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_comparator() {
-
         // Given
         Stream<String> strings = Stream.of("3", "3", "2", "2", "1", "1");
+        int numberOfMaxes = 10;
+        Comparator<? super String> comparator = null;
 
         // When
-        List<String> list = StreamsUtils.filteringMaxKeys(strings, 10, null).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+            StreamsUtils.filteringMaxKeys(strings, numberOfMaxes, comparator)
+                            .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/FilteringMaxValuesSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/FilteringMaxValuesSpliteratorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -176,23 +177,37 @@ public class FilteringMaxValuesSpliteratorTest {
         assertThat(count).isEqualTo(2L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_stream() {
-
         // Given
+        Stream<String> strings = null;
+        int numberOfMaxes = 10;
         Comparator<String> comparator = Comparator.naturalOrder();
 
         // When
-        List<String> list = StreamsUtils.filteringMaxValues(null, 10, comparator).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+                StreamsUtils.filteringMaxValues(strings, numberOfMaxes, comparator)
+                        .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_filtering_spliterator_on_a_null_comparator() {
-
         // Given
         Stream<String> strings = Stream.of("3", "3", "2", "2", "1", "1");
+        int numberOfMaxes = 10;
+        Comparator<String> comparator = null;
 
         // When
-        List<String> list = StreamsUtils.filteringMaxValues(strings, 10, null).collect(toList());
+        Throwable throwable = catchThrowable(() ->
+                StreamsUtils.filteringMaxValues(strings, numberOfMaxes, comparator)
+                        .collect(toList())
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/GroupingOnGatingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/GroupingOnGatingSpliteratorTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class GroupingOnGatingSpliteratorTest {
 
@@ -165,30 +166,44 @@ public class GroupingOnGatingSpliteratorTest {
         assertThat(count).isEqualTo(11L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_spliterator() {
-
+        // Given
         Predicate<String> open = s -> s.startsWith("o");
         Predicate<String> close = s -> s.startsWith("c");
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(null, open, close);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(null, open, close));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_opening_predicate() {
-
-        Stream<String> strings = Stream.of("one").filter(s -> s.isEmpty());
+        // Given
+        Stream<String> strings = Stream.of("one").filter(String::isEmpty);
+        Predicate<? super String> open = null;
         Predicate<String> close = s -> s.startsWith("c");
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(strings, null, close);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, open, close));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_closing_predicate() {
-
-        Stream<String> strings = Stream.of("one").filter(s -> s.isEmpty());
+        // Given
+        Stream<String> strings = Stream.of("one").filter(String::isEmpty);
         Predicate<String> open = s -> s.startsWith("o");
+        Predicate<String> close = null;
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(strings, open, null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, open, close));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/GroupingOnSplittingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/GroupingOnSplittingSpliteratorTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class GroupingOnSplittingSpliteratorTest {
 
@@ -36,9 +37,8 @@ public class GroupingOnSplittingSpliteratorTest {
     public void should_group_an_empty_stream_into_an_empty_stream() {
         // Given
         // a trick to create an empty ORDERED stream
-        Stream<String> strings = Stream.of("one").filter(s -> s.isEmpty());
+        Stream<String> strings = Stream.of("one").filter(String::isEmpty);
         Predicate<String> splitter = s -> s.startsWith("o");
-        Predicate<String> close = s -> s.startsWith("c");
 
         // When
         Stream<Stream<String>> groupingOnSplittingStream = StreamsUtils.group(strings, splitter, true);
@@ -142,19 +142,29 @@ public class GroupingOnSplittingSpliteratorTest {
         assertThat(count).isEqualTo(11L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_spliterator() {
-
+        // Given
+        Stream<String> strings = null;
         Predicate<String> splitter = s -> s.startsWith("o");
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(null, splitter);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, splitter));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_opening_predicate() {
+        // Given
+        Stream<String> strings = Stream.of("one").filter(String::isEmpty);
+        Predicate<? super String> splitter = null;
 
-        Stream<String> strings = Stream.of("one").filter(s -> s.isEmpty());
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, splitter));
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(strings, null);
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/GroupingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/GroupingSpliteratorTest.java
@@ -23,12 +23,12 @@ import org.testng.annotations.Test;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class GroupingSpliteratorTest {
 
@@ -111,19 +111,29 @@ public class GroupingSpliteratorTest {
         assertThat(count).isEqualTo(7L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_grouping_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<String> strings = null;
+        int groupingFactor = 3;
 
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(null, 3);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, groupingFactor));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_grouping_spliterator_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
 
         // When
-        Stream<Stream<String>> groupingStream = StreamsUtils.group(strings, 1);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.group(strings, groupingFactor));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/RepeatingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/RepeatingSpliteratorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -87,19 +88,29 @@ public class RepeatingSpliteratorTest {
         assertThat(count).isEqualTo(6L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_repeating_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<Object> stream = null;
+        int repeatingFactor = 3;
 
-        Stream<String> repeatingStream = StreamsUtils.repeat(null, 3);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.repeat(stream, repeatingFactor));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void should_not_build_a_repeating_spliterator_with_a_repeating_factor_of_1() {
         // Given
         Stream<String> stream = Stream.of("a1", "a2");
+        int repeatingFactor = 1;
 
         // When
-        Stream<String> repeatingStream = StreamsUtils.repeat(stream, 1);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.repeat(stream, repeatingFactor));
 
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/RollingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/RollingSpliteratorTest.java
@@ -16,20 +16,18 @@
 
 package org.paumard.spliterators;
 
-import org.junit.Ignore;
 import org.paumard.spliterators.util.TryAdvanceCheckingSpliterator;
 import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
-import java.text.ParseException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -40,7 +38,7 @@ public class RollingSpliteratorTest {
     public void should_roll_an_empty_stream_into_a_stream_of_an_empty_stream() {
         // Given
         // a trick to create an empty ORDERED stream
-        Stream<String> strings = Stream.of("one").filter(s -> s.isEmpty());
+        Stream<String> strings = Stream.of("one").filter(String::isEmpty);
         int groupingFactor = 2;
 
         // When
@@ -102,19 +100,29 @@ public class RollingSpliteratorTest {
         assertThat(count).isEqualTo(12L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_rolling_spliterator_on_a_null_spliterator() {
+        // Given
+        Spliterator<Object> spliterator = null;
+        int grouping = 3;
 
-        RollingSpliterator<String> rollingSpliterator = RollingSpliterator.of(null, 3);
+        // When
+        Throwable throwable = catchThrowable(() -> RollingSpliterator.of(spliterator, grouping));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_rolling_spliterator_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
 
         // When
-        RollingSpliterator<String> rollingSpliterator = RollingSpliterator.of(strings.spliterator(), groupingFactor);
+        Throwable throwable = catchThrowable(() -> RollingSpliterator.of(strings.spliterator(), groupingFactor));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingDoubleTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingDoubleTest.java
@@ -21,13 +21,14 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import java.util.function.Function;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -99,19 +100,31 @@ public class ShiftingWindowAveragingDoubleTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        ToDoubleFunction<String> mapper = Double::parseDouble;
+        Stream<String> stream = null;
+        int rollingFactor = 3;
 
-        StreamsUtils.shiftingWindowAveragingDouble(null, 3, Double::parseDouble);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingDouble(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToDoubleFunction<String> mapper = Double::parseDouble;
 
         // When
-        StreamsUtils.shiftingWindowAveragingDouble(strings, groupingFactor, Double::parseDouble);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingDouble(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingIntTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingIntTest.java
@@ -21,13 +21,14 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.function.ToIntFunction;
 import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -99,19 +100,31 @@ public class ShiftingWindowAveragingIntTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        ToIntFunction<String> mapper = Integer::parseInt;
+        Stream<String> stream = null;
+        int rollingFactor = 3;
 
-        StreamsUtils.<String>shiftingWindowAveragingInt(null, 3, Integer::parseInt);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingInt(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToIntFunction<String> mapper = Integer::parseInt;
 
         // When
-        StreamsUtils.shiftingWindowAveragingInt(strings, groupingFactor, Integer::parseInt);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingInt(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingLongTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowAveragingLongTest.java
@@ -21,12 +21,14 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.function.ToLongFunction;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -98,19 +100,31 @@ public class ShiftingWindowAveragingLongTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        ToLongFunction<String> mapper = Long::parseLong;
+        Stream<String> stream = null;
+        int rollingFactor = 3;
 
-        StreamsUtils.<String>shiftingWindowAveragingLong(null, 3, Long::parseLong);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingLong(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToLongFunction<String> mapper = Long::parseLong;
 
         // When
-        StreamsUtils.shiftingWindowAveragingLong(strings, groupingFactor, Long::parseLong);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowAveragingLong(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowCollectTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowCollectTest.java
@@ -21,13 +21,14 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import java.util.stream.DoubleStream;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -98,19 +99,31 @@ public class ShiftingWindowCollectTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_rolling_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<CharSequence> stream = null;
+        int rollingFactor = 3;
+        Collector<CharSequence, ?, String> collector = joining();
 
-        StreamsUtils.shiftingWindowCollect(null, 3, joining());
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowCollect(stream, rollingFactor, collector));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_rolling_spliterator_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        Collector<CharSequence, ?, String> collector = joining();
 
         // When
-        StreamsUtils.shiftingWindowCollect(strings, groupingFactor, joining());
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowCollect(strings, groupingFactor, collector));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingDoubleTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingDoubleTest.java
@@ -21,13 +21,13 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import java.util.stream.DoubleStream;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -102,19 +102,31 @@ public class ShiftingWindowSummarizingDoubleTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        Stream<String> stream = null;
+        int rollingFactor = 3;
+        ToDoubleFunction<String> mapper = Double::parseDouble;
 
-        StreamsUtils.shiftingWindowSummarizingDouble(null, 3, Double::parseDouble);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingDouble(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToDoubleFunction<String> mapper = Double::parseDouble;
 
         // When
-        StreamsUtils.shiftingWindowSummarizingDouble(strings, groupingFactor, Double::parseDouble);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingDouble(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingIntTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingIntTest.java
@@ -21,11 +21,13 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -100,19 +102,31 @@ public class ShiftingWindowSummarizingIntTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        Stream<String> stream = null;
+        int rollingFactor = 3;
+        ToIntFunction<String> mapper = Integer::parseInt;
 
-        StreamsUtils.<String>shiftingWindowSummarizingInt(null, 3, Integer::parseInt);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingInt(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToIntFunction<String> mapper = Integer::parseInt;
 
         // When
-        StreamsUtils.shiftingWindowSummarizingInt(strings, groupingFactor, Integer::parseInt);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingInt(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingLongTest.java
+++ b/src/test/java/org/paumard/spliterators/ShiftingWindowSummarizingLongTest.java
@@ -21,11 +21,13 @@ import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -100,19 +102,31 @@ public class ShiftingWindowSummarizingLongTest {
         assertThat(count).isEqualTo(5L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_shifting_stream_on_a_null_stream() {
+        // Given
+        Stream<String> stream = null;
+        int rollingFactor = 3;
+        ToLongFunction<String> mapper = Long::parseLong;
 
-        StreamsUtils.<String>shiftingWindowSummarizingLong(null, 3, Long::parseLong);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingLong(stream, rollingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_shifting_stream_with_a_grouping_factor_of_1() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
         int groupingFactor = 1;
+        ToLongFunction<String> mapper = Long::parseLong;
 
         // When
-        StreamsUtils.shiftingWindowSummarizingLong(strings, groupingFactor, Long::parseLong);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.shiftingWindowSummarizingLong(strings, groupingFactor, mapper));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/TraversingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/TraversingSpliteratorTest.java
@@ -27,12 +27,12 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
  */
 public class TraversingSpliteratorTest {
-
 
     @Test
     public void should_a_return_stream_of_empty_stream_if_provided_streams_are_empty() {
@@ -122,18 +122,27 @@ public class TraversingSpliteratorTest {
         assertThat(count).isEqualTo(6L);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_transversal_spliterator_on_a_null_spliterator() {
+        // Given
+        Stream<Object>[] streams = null;
 
-        Stream<Stream<String>> traversingStream = StreamsUtils.traverse(null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.traverse(streams));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_transversal_spliterator_on_only_one_spliterator() {
         // Given
         Stream<String> streamA = Stream.of("a1", "a2");
 
         // When
-        Stream<Stream<String>> traversingStream = StreamsUtils.traverse(streamA);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.traverse(streamA));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/org/paumard/spliterators/WeavingSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/WeavingSpliteratorTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Created by José
@@ -39,8 +40,8 @@ public class WeavingSpliteratorTest {
     public void should_weave_empty_streams_into_a_stream_of_an_empty_stream() {
         // Given
         // a trick to create an empty ORDERED stream
-        Stream<String> strings1 = Stream.of("one").filter(s -> s.isEmpty());
-        Stream<String> strings2 = Stream.of("one").filter(s -> s.isEmpty());
+        Stream<String> strings1 = Stream.of("one").filter(String::isEmpty);
+        Stream<String> strings2 = Stream.of("one").filter(String::isEmpty);
 
         // When
         Stream<String> weavingStream = StreamsUtils.weave(strings1, strings2);
@@ -93,19 +94,28 @@ public class WeavingSpliteratorTest {
         assertThat(stream.spliterator().characteristics() & Spliterator.SORTED).isEqualTo(0);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void should_not_build_a_weaving_spliterator_on_null() {
+        // Given
+        Stream<String>[] streams = null;
 
-        Stream<String> weavingStream = StreamsUtils.weave(null);
+        // When
+        Throwable throwable = catchThrowable(() -> StreamsUtils.weave(streams));
+
+        // Then
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException .class)
+    @Test
     public void should_not_build_a_weaving_spliterator_on_less_than_two_spliterators() {
         // Given
         Stream<String> strings = Stream.of("1", "2", "3", "4", "5", "6", "7");
 
         // When
-        Stream<String> weavingStream = StreamsUtils.weave(strings);
+        Throwable throwable = catchThrowable(() -> StreamsUtils.weave(strings));
+
+        // Then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
Rather than breaking format when a test should succeed when an exception is thrown, we can use catchThrowable to extract that Throwable and then assert stuff on it.