### PR TITLE
Fixed estimateSize methods

### DIFF
--- a/src/main/java/org/paumard/spliterators/FilteringAllMaxSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/FilteringAllMaxSpliterator.java
@@ -92,7 +92,7 @@ public class FilteringAllMaxSpliterator<E> implements Spliterator<E> {
 
     @Override
     public long estimateSize() {
-        return 0L;
+        return spliterator.estimateSize() > 0 ? 1L : 0L;
     }
 
     @Override

--- a/src/main/java/org/paumard/spliterators/FilteringMaxKeysSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/FilteringMaxKeysSpliterator.java
@@ -87,7 +87,8 @@ public class FilteringMaxKeysSpliterator<E> implements Spliterator<E> {
 
     @Override
     public long estimateSize() {
-        return 0L;
+        long maxSize = spliterator.estimateSize();
+        return maxSize >= numberOfMaxes ? numberOfMaxes : maxSize;
     }
 
     @Override

--- a/src/main/java/org/paumard/spliterators/FilteringMaxValuesSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/FilteringMaxValuesSpliterator.java
@@ -87,7 +87,8 @@ public class FilteringMaxValuesSpliterator<E> implements Spliterator<E> {
 
     @Override
     public long estimateSize() {
-        return 0L;
+        long maxSize = spliterator.estimateSize();
+        return maxSize >= numberOfMaxes ? numberOfMaxes : maxSize;
     }
 
     @Override

--- a/src/main/java/org/paumard/spliterators/RollingOfDoubleSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/RollingOfDoubleSpliterator.java
@@ -103,7 +103,7 @@ public class RollingOfDoubleSpliterator implements Spliterator<DoubleStream> {
 	@Override
 	public long estimateSize() {
 		long estimateSize = spliterator.estimateSize();
-		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping;
+		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping + 1;
 	}
 
 	@Override

--- a/src/main/java/org/paumard/spliterators/RollingOfIntSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/RollingOfIntSpliterator.java
@@ -103,7 +103,7 @@ public class RollingOfIntSpliterator implements Spliterator<IntStream> {
 	@Override
 	public long estimateSize() {
 		long estimateSize = spliterator.estimateSize();
-		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping;
+		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping + 1;
 	}
 
 	@Override

--- a/src/main/java/org/paumard/spliterators/RollingOfLongSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/RollingOfLongSpliterator.java
@@ -103,7 +103,7 @@ public class RollingOfLongSpliterator implements Spliterator<LongStream> {
 	@Override
 	public long estimateSize() {
 		long estimateSize = spliterator.estimateSize();
-		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping;
+		return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping + 1;
 	}
 
 	@Override

--- a/src/main/java/org/paumard/spliterators/RollingSpliterator.java
+++ b/src/main/java/org/paumard/spliterators/RollingSpliterator.java
@@ -113,7 +113,7 @@ public class RollingSpliterator<E> implements Spliterator<Stream<E>> {
     @Override
     public long estimateSize() {
         long estimateSize = spliterator.estimateSize();
-        return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping;
+        return estimateSize == Long.MAX_VALUE ? Long.MAX_VALUE : estimateSize - grouping + 1;
     }
 
     @Override

--- a/src/test/java/org/paumard/spliterators/CrossProductSpliteratorTest.java
+++ b/src/test/java/org/paumard/spliterators/CrossProductSpliteratorTest.java
@@ -16,17 +16,17 @@
 
 package org.paumard.spliterators;
 
-import org.paumard.spliterators.util.TryAdvanceCheckingSpliterator;
 import org.paumard.streams.StreamsUtils;
 import org.testng.annotations.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.paumard.spliterators.util.TryAdvanceCheckingSpliterator.monitorStream;
 
 /**
  * Created by José
@@ -144,18 +144,33 @@ public class CrossProductSpliteratorTest {
     }
 
     @Test
-    public void should_conform_to_specified_trySplit_behavior() {
+    public void should_produce_number_of_original_elements_squared_new_elements() {
         // Given
-        Stream<String> strings = Stream.of("a", "d", "c", "b");
-        Stream<Map.Entry<String, String>> stream = StreamsUtils.crossProduct(strings);
-        TryAdvanceCheckingSpliterator<Map.Entry<String, String>> spliterator = new TryAdvanceCheckingSpliterator<>(stream.spliterator());
-        Stream<Map.Entry<String, String>> monitoredStream = StreamSupport.stream(spliterator, false);
+        List<String> strings = Arrays.asList("a", "d", "c", "b");
 
         // When
+        Stream<Map.Entry<String, String>> monitoredStream = monitorStream(StreamsUtils.crossProduct(strings.stream()));
         long count = monitoredStream.count();
 
         // Then
-        assertThat(count).isEqualTo(16L);
+        assertThat(count).isEqualTo(strings.size() * strings.size());
+    }
+
+    @Test
+    public void should_produce_full_cross_product_of_elements() {
+        // Given
+        Stream<String> strings = Stream.of("a", "d", "c", "b");
+
+        // When
+        Stream<Map.Entry<String, String>> monitoredStream = monitorStream(StreamsUtils.crossProduct(strings));
+
+        // Then
+        assertThat(monitoredStream).containsExactlyInAnyOrder(
+                entry("a", "a"), entry("a", "b"), entry("a", "c"), entry("a", "d"),
+                entry("b", "a"), entry("b", "b"), entry("b", "c"), entry("b", "d"),
+                entry("c", "a"), entry("c", "b"), entry("c", "c"), entry("c", "d"),
+                entry("d", "a"), entry("d", "b"), entry("d", "c"), entry("d", "d")
+        );
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/org/paumard/spliterators/util/TryAdvanceCheckingSpliterator.java
+++ b/src/test/java/org/paumard/spliterators/util/TryAdvanceCheckingSpliterator.java
@@ -1,55 +1,63 @@
 package org.paumard.spliterators.util;
 
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class TryAdvanceCheckingSpliterator<T> implements Spliterator<T> {
 
-        private Spliterator<T> spliterator;
+    private Spliterator<T> spliterator;
 
-        public TryAdvanceCheckingSpliterator(Spliterator<T> spliterator) {
-            this.spliterator = spliterator;
-        }
+    public static <K, V> Stream<Map.Entry<K, V>> monitorStream(Stream<Map.Entry<K, V>> stream) {
+        TryAdvanceCheckingSpliterator<Map.Entry<K, V>> spliterator = new TryAdvanceCheckingSpliterator<>(stream.spliterator());
+        return StreamSupport.stream(spliterator, false);
+    }
 
-        @Override
-        public boolean tryAdvance(Consumer<? super T> action) {
-            AtomicBoolean hasBeenCalled = new AtomicBoolean(false);
+    public TryAdvanceCheckingSpliterator(Spliterator<T> spliterator) {
+        this.spliterator = spliterator;
+    }
 
-            Consumer<T> consumer = t -> {
-                if (hasBeenCalled.getAndSet(true)) {
-                    throw new IllegalStateException("Double call on the passed consumer");
-                } else {
-                    action.accept(t);
-                }
-            };
+    @Override
+    public boolean tryAdvance(Consumer<? super T> action) {
+        AtomicBoolean hasBeenCalled = new AtomicBoolean(false);
 
-
-            boolean hasMore = this.spliterator.tryAdvance(consumer);
-            if (!hasMore && hasBeenCalled.get()) {
-                throw new IllegalStateException("The passed consumer has been called and the returned value is false");
+        Consumer<T> consumer = t -> {
+            if (hasBeenCalled.getAndSet(true)) {
+                throw new IllegalStateException("Double call on the passed consumer");
+            } else {
+                action.accept(t);
             }
-            if (hasMore && !hasBeenCalled.get()) {
-                throw new IllegalStateException("The passed consumer has not been called and the returned value is true");
-            }
-            return hasMore;
-        }
+        };
 
-        @Override
-        public Spliterator<T> trySplit() {
-            return null;
-        }
 
-        @Override
-        public long estimateSize() {
-            return this.spliterator.estimateSize();
+        boolean hasMore = this.spliterator.tryAdvance(consumer);
+        if (!hasMore && hasBeenCalled.get()) {
+            throw new IllegalStateException("The passed consumer has been called and the returned value is false");
         }
+        if (hasMore && !hasBeenCalled.get()) {
+            throw new IllegalStateException("The passed consumer has not been called and the returned value is true");
+        }
+        return hasMore;
+    }
 
-        @Override
-        public int characteristics() {
-            return this.spliterator.characteristics();
-        }
+    @Override
+    public Spliterator<T> trySplit() {
+        return null;
+    }
+
+    @Override
+    public long estimateSize() {
+        return this.spliterator.estimateSize();
+    }
+
+    @Override
+    public int characteristics() {
+        return this.spliterator.characteristics();
+    }
 
     @Override
     public Comparator<? super T> getComparator() {


### PR DESCRIPTION
The implementation of ReferencePipeline#count changed with JDK 9; this causes the Spliterator#estimateSize method to be called when the size of a stream should be detected.

This change fixes the estimateSize methods to give more accurate estimates.